### PR TITLE
Add Installation Instruction to README

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,7 +1,8 @@
 {
   "core": "https://wordpress.org/wordpress-6.0.1.zip",
   "plugins": [
-    "https://downloads.wordpress.org/plugin/wpglobus.zip"
+    "https://downloads.wordpress.org/plugin/wpglobus.zip",
+    "https://downloads.wordpress.org/plugin/classic-editor.zip"
   ],
   "themes": [
     ".",

--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Finally, on the WP admin dashboard, go to _Appearance / Themes / Midsommarkranse
 http://localhost:8888/wp-admin/themes.php?theme=www.mkdevops.se
 
 
+## Installation
+
+How to install the theme in your WordPress site via the admin dashboard:
+
+1. Open _Plugins_ page, click on the _Add New_ button, and install the [WPGlobus](https://wordpress.org/plugins/wpglobus/) plugin
+2. Activate the WPGlobus plugin and configure languages _Swedish_ and _English_ only, removing the other defaults, following the [WPGlobus Quick Start Guide](https://wpglobus.com/quick-start/)
+3. Open _Settings_ > _Permalinks_ > _Common Settings_ and select the "Post name" alternative, then _Save Changes_
+4. Open _Plugins_ page, click on the _Add New_ button, and install the [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin
+5. Open _Pages_ > _Add New_ and create a page with English title "IT Services", _Save Draft_, and Swedish title "IT-tjänster", then _Publish_
+6. Create another page with English title "Consulting", _Save Draft_, and Swedish title "Konsulttjänster", then _Publish_
+7. Download the repo zip archive, https://github.com/mkdevops-se/www.mkdevops.se/archive/refs/heads/main.zip, and upload it under _Appearance_ > _Themes_ > _Add New_ > _Upload Theme_ > _Install Now_, then activate the theme
+
+
 ## Contributing
 
 Do you want to contribute to making this WordPress theme into a shining example of latest _best practices_? Please don't


### PR DESCRIPTION
An initial stab at resolving #11, new README section added:

## Installation

How to install the theme in your WordPress site via the admin dashboard:

1. Open _Plugins_ page, click on the _Add New_ button, and install the [WPGlobus](https://wordpress.org/plugins/wpglobus/) plugin
2. Activate the WPGlobus plugin and configure languages _Swedish_ and _English_ only, removing the other defaults, following the [WPGlobus Quick Start Guide](https://wpglobus.com/quick-start/)
3. Open _Settings_ > _Permalinks_ > _Common Settings_ and select the "Post name" alternative, then _Save Changes_
4. Open _Plugins_ page, click on the _Add New_ button, and install the [Classic Editor](https://wordpress.org/plugins/classic-editor/) plugin
5. Open _Pages_ > _Add New_ and create a page with English title "IT Services", _Save Draft_, and Swedish title "IT-tjänster", then _Publish_
6. Create another page with English title "Consulting", _Save Draft_, and Swedish title "Konsulttjänster", then _Publish_
7. Download the repo zip archive, https://github.com/mkdevops-se/www.mkdevops.se/archive/refs/heads/main.zip, and upload it under _Appearance_ > _Themes_ > _Add New_ > _Upload Theme_ > _Install Now_, then activate the theme